### PR TITLE
correct move to token head function

### DIFF
--- a/conllu-parse.el
+++ b/conllu-parse.el
@@ -67,7 +67,7 @@
    (conllu--tab)
    (conllu--maybe-empty-field)
    (conllu--tab)
-   (conllu--index)
+   (conllu--index) ; TODO: can be empty
    (conllu--tab)
    (conllu--maybe-empty-field)
    (conllu--tab)


### PR DESCRIPTION
moving to head token now works regardless of the presence of multi-word and empty tokens.

closes #5. 

plus:
- add new looking-at functions and mv new ones from conllu-align to conllu-move
- add '--' convention to conllu-align