### PR TITLE
Prevent " from fontifying as string

### DIFF
--- a/conllu-mode.el
+++ b/conllu-mode.el
@@ -81,6 +81,7 @@
     (modify-syntax-entry ?_ "w" st) ; _ is (part of) word, not whitespace
     (modify-syntax-entry ?, "w" st)
     (modify-syntax-entry ?. "w" st)
+    (modify-syntax-entry ?\" "w" st)
     (modify-syntax-entry ?# "<" st) ; begins comment
     (modify-syntax-entry ?\n ">" st) ; ends comment
     st)


### PR DESCRIPTION
Make " a word character in the conllu syntax table so that it doesn't fontify as a string.