### PR TITLE
Only require cl-lib on compile

### DIFF
--- a/conllu-move.el
+++ b/conllu-move.el
@@ -35,7 +35,9 @@
 ;; - in a token line, jump to its head
 
 (require 'conllu-parse)
-(require 'cl-lib)
+
+(eval-when-compile
+  (require 'cl-lib))
 
 ;;; Code:
 


### PR DESCRIPTION
cl-lib is only required on compile as the only macro used is cl-destructuring-bind, so don't require it when it is not needed.