### PR TITLE
move several functions to conllu-thing.el

### DIFF
--- a/conllu-align.el
+++ b/conllu-align.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.1.3
+;; Version: 0.1.4
 ;; Package-Requires: ((emacs "25") (s "1.0") (cl-lib "0.5"))
 ;; Keywords: extensions
 ;; Note: this code is a simplified version of the one in csv-mode.el.
@@ -35,6 +35,7 @@
 ;; - jumping to next or previous sentence
 ;; - in a token line, jump to its head
 
+(require 'conllu-thing)
 (require 'conllu-move)
 
 ;;; Code:
@@ -58,20 +59,6 @@ means left align text and right align numbers."
   :type '(choice (const left) (const centre)
                  (const right) (const auto))
   :group 'conllu-align-group)
-
-(defun conllu--sentence-begin-point ()
-  "Return point of the beginning of current sentence."
-  (save-excursion (backward-sentence) (point)))
-
-(defun conllu--sentence-end-point ()
-  "Return point of the end of current sentence."
-  (save-excursion (forward-sentence) (point)))
-
-(defun conllu--sentence-points ()
-  "Return points that delimit current sentence."
-  (let ((start (conllu--sentence-begin-point))
-        (end (conllu--sentence-end-point)))
-    (list start end)))
 
 (defun conllu--column-widths ()
   (let ((widths '()))

--- a/conllu-mode.el
+++ b/conllu-mode.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.1.3
+;; Version: 0.1.4
 ;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0"))
 ;; Keywords: extensions
 
@@ -90,16 +90,16 @@ string in the minibuffer, else display the empty field as default string."
     (define-key map [(control ?c) (control ?e)] #'conllu-edit-field)
     (define-key map [(control ?c) (control ?u)] #'conllu-unalign-fields)
     (define-key map [(control ?c) (control ?h)] #'conllu-move-to-head)
-    (define-key map [(control ?c) ?1] 'conllu-field-number-1)
-    (define-key map [(control ?c) ?2] 'conllu-field-number-2)
-    (define-key map [(control ?c) ?3] 'conllu-field-number-3)
-    (define-key map [(control ?c) ?4] 'conllu-field-number-4)
-    (define-key map [(control ?c) ?5] 'conllu-field-number-5)
-    (define-key map [(control ?c) ?6] 'conllu-field-number-6)
-    (define-key map [(control ?c) ?7] 'conllu-field-number-7)
-    (define-key map [(control ?c) ?8] 'conllu-field-number-8)
-    (define-key map [(control ?c) ?9] 'conllu-field-number-9)
-    (define-key map [(control ?c) ?0] 'conllu-field-number-10)
+    (define-key map [(control ?c) ?1] 'conllu-move-to-field-number-1)
+    (define-key map [(control ?c) ?2] 'conllu-move-to-field-number-2)
+    (define-key map [(control ?c) ?3] 'conllu-move-to-field-number-3)
+    (define-key map [(control ?c) ?4] 'conllu-move-to-field-number-4)
+    (define-key map [(control ?c) ?5] 'conllu-move-to-field-number-5)
+    (define-key map [(control ?c) ?6] 'conllu-move-to-field-number-6)
+    (define-key map [(control ?c) ?7] 'conllu-move-to-field-number-7)
+    (define-key map [(control ?c) ?8] 'conllu-move-to-field-number-8)
+    (define-key map [(control ?c) ?9] 'conllu-move-to-field-number-9)
+    (define-key map [(control ?c) ?0] 'conllu-move-to-field-number-10)
     (define-key map [(meta ?e)] 'conllu-forward-sentence)
     (define-key map [(meta ?n)] 'conllu-next-sentence)
     (define-key map [(meta ?p)] 'conllu-previous-sentence)

--- a/conllu-move.el
+++ b/conllu-move.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.1.3
+;; Version: 0.1.4
 ;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0"))
 ;; Keywords: extensions
 
@@ -35,6 +35,7 @@
 ;; - in a token line, jump to its head
 
 (require 'conllu-parse)
+(require 'conllu-thing)
 
 (eval-when-compile
   (require 'cl-lib))
@@ -58,64 +59,63 @@ if at end of sentence, go to next line."
   (conllu--skip-forward-to-end-of-field)
   (forward-char))
 
-(defun conllu--field-number (n)
+(defun conllu--move-to-field-number (n)
   "Move to field number N.
 N must be inbouds, i.e., 0 < N <= 10."
   (beginning-of-line)
-  (when (conllu--not-looking-at-token) ;; should I make a function for this?
-    (user-error "%s" "Error: not at token line"))
+  (conllu--barf-if-not-at-token-line)
   (dotimes (_t (1- n) t)
     (conllu-field-forward)))
 
-(defun conllu-field-number-1 ()
+(defun conllu-move-to-field-number-1 ()
   "Move point to field ID."
   (interactive)
-  (conllu--field-number 1))
+  (conllu--move-to-field-number 1))
 
-(defun conllu-field-number-2 ()
+(defun conllu-move-to-field-number-2 ()
   "Move point to field FORM."
   (interactive)
-  (conllu--field-number 2))
+  (conllu--move-to-field-number 2))
 
-(defun conllu-field-number-3 ()
+(defun conllu-move-to-field-number-3 ()
   "Move point to field LEMMA."
   (interactive)
-  (conllu--field-number 3))
+  (conllu--move-to-field-number 3))
 
-(defun conllu-field-number-4 ()
+(defun conllu-move-to-field-number-4 ()
   "Move point to field UPOSTAG."
   (interactive)
-  (conllu--field-number 4))
+  (conllu--move-to-field-number 4))
 
-(defun conllu-field-number-5 ()
+(defun conllu-move-to-field-number-5 ()
   "Move point to field XPOSTAG."
   (interactive)
-  (conllu--field-number 5))
+  (conllu--move-to-field-number 5))
 
-(defun conllu-field-number-6 ()
+(defun conllu-move-to-field-number-6 ()
   "Move point to field FEATS."
   (interactive)
-  (conllu--field-number 6))
+  (conllu--move-to-field-number 6))
 
-(defun conllu-field-number-7 ()
+(defun conllu-move-to-field-number-7 ()
   "Move point to field HEAD."
   (interactive)
-  (conllu--field-number 7))
+  (conllu--move-to-field-number 7))
 
-(defun conllu-field-number-8 ()
+(defun conllu-move-to-field-number-8 ()
   "Move point to field DEPREL."
   (interactive)
-  (conllu--field-number 8))
+  (conllu--move-to-field-number 8))
 
-(defun conllu-field-number-9 ()
+(defun conllu-move-to-field-number-9 ()
   "Move point to field DEPS."
   (interactive)
-  (conllu--field-number 9))
+  (conllu--move-to-field-number 9))
 
-(defun conllu-field-number-10 ()
+(defun conllu-move-to-field-number-10 ()
   "Move point to field MISC."
   (interactive)
-  (conllu--field-number 10))
+  (conllu--move-to-field-number 10))
 
 (defun conllu-field-backward ()
   "Move to previous field.
@@ -124,36 +124,6 @@ if at beginning of sentence, go to previous line"
   (skip-chars-backward "^[\t\n]")
   (forward-char -1)
   (skip-chars-backward "^[\t\n]"))
-
-;;;
-;; token
-;< looking at functions
-(defsubst conllu--not-looking-at-token ()
-  "Return t if looking at blank or comment line, nil otherwise.
-Assumes point is at beginning of line."
-  (looking-at (concat " *$" "\\|" "#")))
-
-;; tokens are divided in simple, multi and empty tokens.
-(defsubst conllu--looking-at-stoken ()
-  "Return t if looking at a simple token line, nil otherwise.
-Assumes point is at beginning of line."
-  (looking-at "[0-9]*[^-.]\t"))
-
-(defsubst conllu--looking-at-mtoken ()
-  "Return t if looking at a multi-token line, nil otherwise.
-assumes point is at beginning of line."
-  (looking-at "[0-9]*-[0-9]*\t"))
-
-(defsubst conllu--looking-at-etoken ()
-  "Return t if looking at an empty token line, nil otherwise.
-assumes point is at beginning of line."
-  (looking-at "[0-9]*\\.[0-9]*\t"))
-;>
-
-(defun conllu--barf-if-not-at-token-line (&optional message)
-  "Displays error MESSAGE if not at token line."
-  (when (conllu--not-looking-at-token)
-    (user-error "%s" (or message "Error: not at token line"))))
 
 ;< move to token head
 (defun conllu-move-to-head ()
@@ -188,19 +158,6 @@ if root, moves to beginning of sentence."
         (progn (forward-line 1)
                (conllu--move-to-head head)))
        (t (beginning-of-line))))))
-
-(defun conllu--id> (id id2)
-  "Return t if CoNLL-U field ID is greater than ID2."
-  (pcase (cons id id2)
-    (`((,_ ,beg ,_) . (,_ ,beg2 ,_))
-     ; todo: does this ever happen? if so it's incorrect
-     (> beg beg2))
-    (`((,_ ,beg ,_) . ,n)
-     (> beg n))
-    (`(,n . (,_ ,beg ,_))
-     (> n beg))
-    (`(,n . ,n2)
-     (> n n2))))
 ;>
 
 ;;;

--- a/conllu-parse.el
+++ b/conllu-parse.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.1.3
+;; Version: 0.1.4
 ;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0"))
 ;; Keywords: extensions
 

--- a/conllu-thing.el
+++ b/conllu-thing.el
@@ -1,0 +1,115 @@
+;;; conllu-thing.el --- utilities for CoNLL-U files  -*- lexical-binding: t; -*-
+;; Copyright (C) 2018 bruno cuconato
+
+;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
+;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
+;; URL: https://github.com/odanoburu/conllu-mode
+;; Version: 0.1.4
+;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0"))
+;; Keywords: extensions
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; this mode provides simple utilities for editing and viewing CoNLL-U
+;; files.
+
+;; it offers the following features, and more:
+
+;; - highlighting comments, and upostag and deprel fields
+;; - truncate lines by default
+;; - show newline and tab characters using whitespace.el
+;; - aligning and unaligning column fields
+;; - jumping to next or previous sentence
+;; - in a token line, jump to its head
+
+;;; code:
+
+;;;
+;; dependencies
+(require 'cl-lib)
+(require 's)
+
+;;;
+;; token
+;< looking at functions
+(defsubst conllu--looking-at (regexp)
+  "Call `looking-at' at the beginning-of-line and return its result.
+Return point to original position."
+  (save-excursion (beginning-of-line)
+                  (looking-at regexp)))
+
+(defsubst conllu--not-looking-at-token ()
+  "Return t if looking at blank or comment line, nil otherwise."
+  (conllu--looking-at " *$\\|#"))
+
+;; tokens are divided in simple, multi and empty tokens.
+(defsubst conllu--looking-at-stoken ()
+  "Return t if looking at a simple token line, nil otherwise."
+  (conllu--looking-at "[0-9]+[^-.]"))
+
+(defsubst conllu--looking-at-mtoken ()
+  "Return t if looking at a multi-token line, nil otherwise."
+  (conllu--looking-at "[0-9]+-[0-9]"))
+
+(defsubst conllu--looking-at-etoken ()
+  "Return t if looking at an empty token line, nil otherwise."
+  (conllu--looking-at "[0-9]+\\.[0-9]"))
+;>
+
+(defun conllu--barf-if-not-at-token-line (&optional message)
+  "Displays error MESSAGE if not at token line."
+  (when (conllu--not-looking-at-token)
+    (user-error "%s" (or message "Error: not at token line"))))
+
+(defun conllu--id> (id id2)
+  "Return t if CoNLL-U field ID is greater than ID2."
+  (pcase (cons id id2)
+    (`((,_ ,beg ,_) . (,_ ,beg2 ,_))
+     ; todo: does this ever happen? if so it's incorrect
+     (> beg beg2))
+    (`((,_ ,beg ,_) . ,n)
+     (> beg n))
+    (`(,n . (,_ ,beg ,_))
+     (> n beg))
+    (`(,n . ,n2)
+     (> n n2))))
+
+(defun conllu--sentence-begin-point ()
+  "Return point of the beginning of current sentence."
+  (save-excursion (backward-sentence) (point)))
+
+(defun conllu--sentence-tokens-begin-point()
+  "Return point of the beginning of the first token line."
+  (save-excursion (backward-sentence)
+                  (conllu-forward-to-token-line)
+                  (point)))
+
+(defun conllu--sentence-end-point ()
+  "Return point of the end of current sentence."
+  (save-excursion (forward-sentence) (point)))
+
+(defun conllu--sentence-points ()
+  "Return points that delimit current sentence."
+  (list (conllu--sentence-begin-point)
+        (conllu--sentence-end-point)))
+
+(defun conllu--sentence-tokens-points ()
+  "Return points that delimit the token lines of the sentence at point."
+  (list (conllu--sentence-tokens-begin-point)
+        (conllu--sentence-end-point)))
+
+(provide 'conllu-thing)
+
+;;; conllu-thing.el ends here


### PR DESCRIPTION
- rename move-to-field functions
- rm assumption of looking-at-* functions that they were in the
  beginning of the line
  - this was a difficult to find bug waiting to happen