### PR TITLE
realign sentence after edits + validate path to validator

### DIFF
--- a/conllu-align.el
+++ b/conllu-align.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.2.1
+;; Version: 0.2.2
 ;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0") (flycheck "30"))
 ;; Keywords: extensions
 ;; Note: this code is a simplified version of the one in csv-mode.el.
@@ -175,6 +175,31 @@ BEG and END must be point values."
   (mapc #'conllu--delete-overlay (overlays-in beg end))
   (with-silent-modifications
     (remove-list-of-text-properties beg end '(display))))
+
+(defun conllu-realign-sentence ()
+  "Unalign and align current sentence fields."
+  (interactive)
+  (let ((beg (conllu--sentence-begin-point))
+        (end (conllu--sentence-end-point)))
+    (conllu-unalign-fields beg end)
+    (conllu-align-fields beg end)))
+
+(defun conllu--sentence-aligned? ()
+  "Return nil if sentece is not aligned.
+This implementation looks for an overlay with the 'conllu
+property set to t in the first character of the first token
+line. It would be bug if this overlay where there and the
+sentence were not aligned (even if wrongly aligned)."
+  (let* ((beg (conllu--sentence-tokens-begin-point))
+         (ovs (overlays-at beg)))
+    (cl-some (lambda (ov) (overlay-get ov 'conllu)) ovs)))
+
+(defun conllu--sentence-realign-if-aligned ()
+  "Realign sentence if it has been aligned."
+  (when (conllu--sentence-aligned?)
+    (conllu-realign-sentence)
+    nil))
+
 
 (provide 'conllu-align)
 

--- a/conllu-edit.el
+++ b/conllu-edit.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.2.1
+;; Version: 0.2.2
 ;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0") (flycheck "30"))
 ;; Keywords: extensions
 
@@ -39,6 +39,8 @@
 ;;;
 ;; dependencies
 (eval-when-compile (require 'cl-lib))
+(require 's)
+(require 'conllu-align)
 (require 'conllu-move)
 (require 'conllu-thing)
 
@@ -57,19 +59,23 @@ string in the minibuffer, else display the empty field as default string."
   "Empty the field at point."
   (interactive)
   (conllu--clear-field)
-  (insert "_"))
+  (insert "_")
+  (conllu--sentence-realign-if-aligned))
 
 (defun conllu-edit-field ()
   "Interactively edit the field at point."
   (interactive)
   (let ((original-str (conllu--clear-field)))
     (minibuffer-with-setup-hook (lambda () (insert original-str))
-      (call-interactively #'conllu--prompt-for-field-string))))
+      (call-interactively #'conllu--prompt-for-field-string)))
+  (conllu--sentence-realign-if-aligned))
 
 (defun conllu--prompt-for-field-string (str)
   "Prompt for string in the minibuffer and insert it at point."
   (interactive "sString to place in current field:")
-  (insert str))
+  (if (s-blank? str)
+      (insert "_")
+    (insert str)))
 
 (defun conllu-insert-token-line (&optional n)
   "Insert empty token line at point if at beginning of line.

--- a/conllu-flycheck.el
+++ b/conllu-flycheck.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.2.1
+;; Version: 0.2.2
 ;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0") (flycheck "30"))
 ;; Keywords: extensions
 
@@ -45,7 +45,11 @@
   "Set the path to the validate.py script."
   :type 'file
   :group 'conllu
-  :set (lambda (sym val) (when val (set-default sym (file-truename val)))))
+  :set (lambda (sym val) (when val
+                           (let ((fp (file-truename val)))
+                             (if (file-exists-p fp)
+                                 (set-default sym fp)
+                               (user-error "File ~s does not exist" fp))))))
 
 (defun conllu-invoke-flycheck-if-checker-available ()
   "Invoke `flycheck-mode' if `conllu-flycheck-validate.py-path'

--- a/conllu-mode.el
+++ b/conllu-mode.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.2.1
+;; Version: 0.2.2
 ;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0") (flycheck "30"))
 ;; Keywords: extensions
 

--- a/conllu-move.el
+++ b/conllu-move.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.2.1
+;; Version: 0.2.2
 ;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0") (flycheck "30"))
 ;; Keywords: extensions
 

--- a/conllu-parse.el
+++ b/conllu-parse.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.2.1
+;; Version: 0.2.2
 ;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0") (flycheck "30"))
 ;; Keywords: extensions
 

--- a/conllu-thing.el
+++ b/conllu-thing.el
@@ -4,7 +4,7 @@
 ;; Author: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; Maintainer: bruno cuconato <bcclaro+emacs@gmail.com>
 ;; URL: https://github.com/odanoburu/conllu-mode
-;; Version: 0.2.1
+;; Version: 0.2.2
 ;; Package-Requires: ((emacs "25") (cl-lib "0.5") (s "1.0") (flycheck "30"))
 ;; Keywords: extensions
 
@@ -200,7 +200,7 @@ the first of the two numbers."
   "Return point of the beginning of current sentence."
   (save-excursion (backward-sentence) (point)))
 
-(defun conllu--sentence-tokens-begin-point()
+(defun conllu--sentence-tokens-begin-point ()
   "Return point of the beginning of the first token line."
   (save-excursion (backward-sentence)
                   (conllu-forward-to-token-line)
@@ -211,7 +211,7 @@ the first of the two numbers."
   (save-excursion (forward-sentence) (point)))
 
 (defun conllu--sentence-points ()
-  "Return points that delimit current sentence."
+  "Return points that delimit current sentence in a list."
   (save-excursion
     ;; can't use conllu--sentence-begin-point because they save
     ;; excursion


### PR DESCRIPTION
- validate if conllu-flycheck-validate.py-path is an existing path (closes #29)
- realign sentence after editing it (closes #28)
- insert empty token ('_') if user enters an empty string in
  conllu-edit-field